### PR TITLE
Streamline CLAUDE.md and extract screenshot upload helper

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,30 +2,10 @@
 
 ## Build
 
-```
-make build
-```
+`make build` — runs `make fmt_check` then `npm run build`.
+To auto-format first: `make fmt && make build`.
 
-Runs `make fmt_check` then `npm run build`. To auto-format first: `make fmt && make build`.
-
-## Shortcodes
-
-```liquid
-{% image "url", "alt text" %}
-{% image "url", "alt text", 640 %}
-{% image "url", "alt text", 640, "css-class" %}
-
-{% image_with_caption "url", "anchor-id", "Short description." %}
-{% image_with_caption "url", "anchor-id", "Short desc.", "Long description." %}
-
-{% caption "Short description." %}
-{% caption "Short description.", "Long description." %}
-```
-
-## Formatting
-
-Prettier checks `scss/*`, `post/*.md`, `eleventy.config.js`, and `package.json`.
-HTML files in `post/` are excluded (contain Liquid template syntax).
+See README for shortcodes, formatting scope, and deployment details.
 
 ## Style Review Process
 
@@ -35,18 +15,15 @@ abstract — render and look.
 
 ### Workflow
 
-1. **Capture before screenshots** (before touching any files)
+1. Capture before screenshots (before touching any files)
 2. Make style changes
 3. Rebuild: `make build`
-4. **Capture after screenshots**
-5. Read both sets of images and inspect them carefully
-6. Identify and fix any issues found, then repeat from step 3
-7. Only commit once the after screenshots look correct at all viewports
+4. Capture after screenshots
+5. Read both image sets and inspect carefully
+6. Fix any issues found, then repeat from step 3
+7. Commit only once after screenshots look correct at all viewports
 
 ### Taking Screenshots
-
-Start a local server, run `scripts/screenshot.js`, then kill the server.
-Pass an output directory as the first argument (defaults to `/tmp/screenshots`).
 
 ```bash
 cd _site && python3 -m http.server 8765 &
@@ -54,78 +31,33 @@ node scripts/screenshot.js /tmp/screenshots
 kill $(lsof -t -i:8765)
 ```
 
-Read the resulting PNG files directly — Claude can view images.
+### What to Check
 
-### What to Check in Screenshots
-
-- **Mobile (375px)**: Nav links visible without hamburger menu; post list dates
-  on their own line above titles; no horizontal overflow; headings not
-  oversized; adequate spacing around site title
-- **Tablet (768px)**: Date and title on same line; container comfortably
-  narrower than viewport; code blocks contained
-- **Desktop (1280px)**: Centred column looks intentional, not lost; clean
-  typographic hierarchy
+- **Mobile (375px)**: Nav links visible; post list dates on own line above titles;
+  no horizontal overflow; headings not oversized; adequate spacing around site title
+- **Tablet (768px)**: Date and title on same line; container narrower than viewport;
+  code blocks contained
+- **Desktop (1280px)**: Centred column looks intentional; clean typographic hierarchy
 
 ## Pull Requests for Style Changes
 
-Include before/after screenshots in the PR body. Capture "before" by
-stashing changes, building, screenshotting, then unstashing.
+Include before/after screenshots in the PR body. See README for the full workflow
+and screenshot table format.
 
 ```bash
-git stash
-make build
+git stash && make build
 cd _site && python3 -m http.server 8765 &
 node scripts/screenshot.js /tmp/screenshots-before
 kill $(lsof -t -i:8765)
-git stash pop
-make build
+git stash pop && make build
 cd _site && python3 -m http.server 8765 &
 node scripts/screenshot.js /tmp/screenshots-after
 kill $(lsof -t -i:8765)
 ```
 
-Save screenshots to `.github/screenshots/before/` and `.github/screenshots/after/`,
-then upload them to the PR's head branch using the GitHub Contents API and
-embed the resulting raw URLs in a side-by-side table.
+Save to `.github/screenshots/before/` and `.github/screenshots/after/`, then
+upload via (bypasses the local git push proxy):
 
-**Important:** `git push` goes through a local proxy and may not reach the real
-GitHub. Use the Contents API directly to upload files to a branch that already
-exists on GitHub (i.e. the PR's head branch):
-
-```python
-import json, base64, urllib.request, os
-
-TOKEN = os.environ["GITHUB_TOKEN"]
-REPO = "owner/repo"
-BRANCH = "pr-head-branch"   # must already exist on github.com
-
-def gh(method, path, data=None):
-    req = urllib.request.Request(f"https://api.github.com{path}", method=method,
-        headers={"Authorization": f"token {TOKEN}", "Content-Type": "application/json"})
-    if data:
-        req.data = json.dumps(data).encode()
-    with urllib.request.urlopen(req) as r:
-        return json.loads(r.read())
-
-for side in ("before", "after"):
-    for fname in sorted(os.listdir(f".github/screenshots/{side}")):
-        path = f".github/screenshots/{side}/{fname}"
-        content = base64.b64encode(open(path, "rb").read()).decode()
-        existing = gh("GET", f"/repos/{REPO}/contents/{path}?ref={BRANCH}")
-        payload = {"message": f"Add {side} screenshot {fname}", "content": content, "branch": BRANCH}
-        if "sha" in existing:
-            payload["sha"] = existing["sha"]
-        gh("PUT", f"/repos/{REPO}/contents/{path}", payload)
-```
-
-Then reference them via `raw.githubusercontent.com`:
-
-```markdown
-## Screenshots
-
-| Viewport | Before | After |
-|----------|--------|-------|
-| Mobile 375px – homepage | ![before](https://raw.githubusercontent.com/owner/repo/BRANCH/.github/screenshots/before/homepage-mobile-375.png) | ![after](…) |
-| Mobile 375px – post     | ![before](…) | ![after](…) |
-| Desktop – homepage      | ![before](…) | ![after](…) |
+```bash
+GITHUB_TOKEN=<token> python3 scripts/upload_screenshots.py owner/repo pr-head-branch
 ```

--- a/README.md
+++ b/README.md
@@ -68,3 +68,40 @@ make deploy
 [Required environment variables][env]
 
 [env]: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html
+
+## Style PRs
+
+Pull requests that change `scss/styles.scss` or `_layouts/default.njk` must
+include before/after screenshots. Capture them with:
+
+```bash
+# Before
+git stash && make build
+cd _site && python3 -m http.server 8765 &
+node scripts/screenshot.js /tmp/screenshots-before
+kill $(lsof -t -i:8765)
+
+# After
+git stash pop && make build
+cd _site && python3 -m http.server 8765 &
+node scripts/screenshot.js /tmp/screenshots-after
+kill $(lsof -t -i:8765)
+```
+
+Copy screenshots to `.github/screenshots/before/` and `.github/screenshots/after/`,
+then upload to the PR branch via the GitHub Contents API (bypassing the local
+git push proxy):
+
+```bash
+GITHUB_TOKEN=<token> python3 scripts/upload_screenshots.py owner/repo pr-head-branch
+```
+
+Embed them in the PR body using `raw.githubusercontent.com` URLs:
+
+```markdown
+| Viewport | Before | After |
+|----------|--------|-------|
+| Mobile 375px – homepage | ![before](https://raw.githubusercontent.com/owner/repo/BRANCH/.github/screenshots/before/homepage-mobile-375.png) | ![after](…) |
+| Mobile 375px – post     | ![before](…) | ![after](…) |
+| Desktop – homepage      | ![before](…) | ![after](…) |
+```

--- a/scripts/upload_screenshots.py
+++ b/scripts/upload_screenshots.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Upload before/after screenshots to a GitHub branch via the Contents API.
+
+Usage: GITHUB_TOKEN=<token> python3 scripts/upload_screenshots.py <owner/repo> <branch>
+
+The branch must already exist on github.com. Screenshots are read from
+.github/screenshots/before/ and .github/screenshots/after/.
+"""
+
+import base64
+import json
+import os
+import sys
+import urllib.request
+
+
+def gh(token, method, path, data=None):
+    req = urllib.request.Request(
+        f"https://api.github.com{path}",
+        method=method,
+        headers={
+            "Authorization": f"token {token}",
+            "Content-Type": "application/json",
+        },
+    )
+    if data:
+        req.data = json.dumps(data).encode()
+    with urllib.request.urlopen(req) as r:
+        return json.loads(r.read())
+
+
+def upload_screenshots(repo, branch):
+    token = os.environ["GITHUB_TOKEN"]
+    for side in ("before", "after"):
+        for fname in sorted(os.listdir(f".github/screenshots/{side}")):
+            path = f".github/screenshots/{side}/{fname}"
+            content = base64.b64encode(open(path, "rb").read()).decode()
+            existing = gh(token, "GET", f"/repos/{repo}/contents/{path}?ref={branch}")
+            payload = {
+                "message": f"Add {side} screenshot {fname}",
+                "content": content,
+                "branch": branch,
+            }
+            if "sha" in existing:
+                payload["sha"] = existing["sha"]
+            gh(token, "PUT", f"/repos/{repo}/contents/{path}", payload)
+            print(f"Uploaded {path}")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        print(f"Usage: {sys.argv[0]} <owner/repo> <branch>")
+        sys.exit(1)
+    upload_screenshots(sys.argv[1], sys.argv[2])


### PR DESCRIPTION
- Remove Shortcodes and Formatting sections from CLAUDE.md (already in README)
- Condense PR screenshot section to reference script instead of inline Python
- Add Style PRs section to README with full infrastructure details
- Extract GitHub Contents API upload logic to scripts/upload_screenshots.py

https://claude.ai/code/session_0181yrSfwngzsFq5RCBgEgFK