### PR TITLE
Fix lede rendering and add content checks to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,5 +24,8 @@ jobs:
       - name: Check site builds
         run: make build
 
+      - name: Check content structure and images
+        run: make content_check
+
       - name: Check for broken links
         run: make link_check

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,9 @@ fmt:
 fmt_check:
 	npx prettier --check ${CHECK_FILES}
 
+content_check: _site
+	python3 bin/check_content.py
+
 link_check: _site
 	python3 -m http.server --directory _site 8765 & \
 	SERVER_PID=$$!; \

--- a/bin/check_content.py
+++ b/bin/check_content.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""
+Content validation checks for the built site.
+
+Scope: feed posts only (posts with `feed: true` in frontmatter).
+These are the actively maintained posts.
+
+1. Verify that every feed post using :::lede produces a
+   <div class="lede"> element in the corresponding built HTML.
+
+2. Verify that all external image URLs in feed post HTML return HTTP 200.
+"""
+
+import re
+import sys
+import urllib.request
+import urllib.error
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+
+SITE_DIR = Path("_site")
+POSTS_DIR = Path("post")
+
+
+def is_feed_post(md_file: Path) -> bool:
+    """Return True if the post has feed: true in its frontmatter."""
+    text = md_file.read_text()
+    return bool(re.search(r"^feed:\s*true\s*$", text, re.MULTILINE))
+
+
+def get_feed_post_slugs() -> list[str]:
+    return [f.stem for f in POSTS_DIR.glob("*.md") if is_feed_post(f)]
+
+
+def check_lede_rendering(slugs: list[str]) -> list[str]:
+    """Return error messages for feed posts where :::lede did not render."""
+    errors = []
+    for slug in slugs:
+        md_file = POSTS_DIR / f"{slug}.md"
+        source = md_file.read_text()
+        if ":::lede" not in source:
+            continue
+
+        html_file = SITE_DIR / "post" / slug / "index.html"
+        if not html_file.exists():
+            errors.append(f"MISSING built HTML for {md_file}: {html_file}")
+            continue
+
+        html = html_file.read_text()
+        if '<div class="lede">' not in html:
+            errors.append(
+                f"LEDE NOT RENDERED in {md_file}: "
+                f'expected <div class="lede"> in {html_file}'
+            )
+    return errors
+
+
+def check_url(url: str) -> str | None:
+    """Return an error string if the URL does not return HTTP 200, else None."""
+    try:
+        req = urllib.request.Request(url, method="HEAD")
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            if resp.status != 200:
+                return f"HTTP {resp.status}: {url}"
+    except urllib.error.HTTPError as exc:
+        return f"HTTP {exc.code}: {url}"
+    except Exception as exc:
+        return f"ERROR ({exc}): {url}"
+    return None
+
+
+def collect_external_image_urls(slugs: list[str]) -> list[str]:
+    """Extract external https:// image src values from feed post HTML files."""
+    img_pattern = re.compile(r'<img\b[^>]*\bsrc="(https?://[^"]+)"', re.IGNORECASE)
+    urls: set[str] = set()
+    for slug in slugs:
+        html_file = SITE_DIR / "post" / slug / "index.html"
+        if html_file.exists():
+            for match in img_pattern.finditer(html_file.read_text()):
+                urls.add(match.group(1))
+    return sorted(urls)
+
+
+def check_external_images(slugs: list[str]) -> list[str]:
+    """Return error messages for any external image URLs that don't return 200."""
+    urls = collect_external_image_urls(slugs)
+    if not urls:
+        return []
+
+    errors = []
+    with ThreadPoolExecutor(max_workers=10) as pool:
+        futures = {pool.submit(check_url, url): url for url in urls}
+        for future in as_completed(futures):
+            result = future.result()
+            if result:
+                errors.append(result)
+    return errors
+
+
+def main() -> int:
+    if not SITE_DIR.exists():
+        print(
+            "ERROR: _site/ directory not found. Run make build first.", file=sys.stderr
+        )
+        return 1
+
+    slugs = get_feed_post_slugs()
+    if not slugs:
+        print("WARNING: no feed posts found.")
+        return 0
+
+    errors: list[str] = []
+
+    print(f"Checking {len(slugs)} feed post(s): {', '.join(slugs)}")
+
+    print("  Checking lede rendering...")
+    errors.extend(check_lede_rendering(slugs))
+
+    print("  Checking external image URLs...")
+    errors.extend(check_external_images(slugs))
+
+    if errors:
+        print("\nContent check FAILED:", file=sys.stderr)
+        for err in sorted(errors):
+            print(f"  {err}", file=sys.stderr)
+        return 1
+
+    print("All content checks passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -3,6 +3,7 @@ const pluginRss = require("@11ty/eleventy-plugin-rss");
 const embedYouTube = require("eleventy-plugin-youtube-embed");
 const markdownIt = require("markdown-it");
 const markdownItFootnote = require("markdown-it-footnote");
+const markdownItContainer = require("markdown-it-container");
 const syntaxHighlight = require("@11ty/eleventy-plugin-syntaxhighlight");
 
 module.exports = function (config) {
@@ -12,7 +13,9 @@ module.exports = function (config) {
     html: true, // Enable HTML tags in source
     breaks: false, // Don't convert '\n' in paragraphs into <br>
     linkify: true, // Autoconvert URL-like text to links
-  }).use(markdownItFootnote);
+  })
+    .use(markdownItFootnote)
+    .use(markdownItContainer, "lede");
 
   config.setLibrary("md", markdownLib);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@11ty/eleventy-plugin-syntaxhighlight": "^5.0.0",
         "eleventy-plugin-youtube-embed": "^1.6.5",
         "luxon": "^3.0.0",
+        "markdown-it-container": "^4.0.0",
         "markdown-it-footnote": "^3.0.3",
         "sass": "^1.97.3"
       },
@@ -2040,6 +2041,12 @@
       "bin": {
         "markdown-it": "bin/markdown-it.mjs"
       }
+    },
+    "node_modules/markdown-it-container": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-it-container/-/markdown-it-container-4.0.0.tgz",
+      "integrity": "sha512-HaNccxUH0l7BNGYbFbjmGpf5aLHAMTinqRZQAEQbMr2cdD3z91Q6kIo1oUn1CQndkT03jat6ckrdRYuwwqLlQw==",
+      "license": "MIT"
     },
     "node_modules/markdown-it-footnote": {
       "version": "3.0.3",
@@ -4481,6 +4488,11 @@
           "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="
         }
       }
+    },
+    "markdown-it-container": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-it-container/-/markdown-it-container-4.0.0.tgz",
+      "integrity": "sha512-HaNccxUH0l7BNGYbFbjmGpf5aLHAMTinqRZQAEQbMr2cdD3z91Q6kIo1oUn1CQndkT03jat6ckrdRYuwwqLlQw=="
     },
     "markdown-it-footnote": {
       "version": "3.0.3",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@11ty/eleventy-plugin-syntaxhighlight": "^5.0.0",
     "eleventy-plugin-youtube-embed": "^1.6.5",
     "luxon": "^3.0.0",
+    "markdown-it-container": "^4.0.0",
     "markdown-it-footnote": "^3.0.3",
     "sass": "^1.97.3"
   },

--- a/post/rss-feeds-in-science.md
+++ b/post/rss-feeds-in-science.md
@@ -40,4 +40,4 @@ But on a more serious tone, there's no reason that everything you have to monito
 
 <strong>Where to get started</strong>
 
-All you need to use RSS feeds, is a feed reader. I use <a href="www.google.com/reader">Google Reader</a>, all that's required is a Google log in.
+All you need to use RSS feeds, is a feed reader. I use <a href="http://www.google.com/reader">Google Reader</a>, all that's required is a Google log in.


### PR DESCRIPTION
- Add markdown-it-container dependency so :::lede blocks render as
  <div class="lede"> instead of literal :::lede text
- Add bin/check_content.py to validate feed posts: verifies lede
  blocks render correctly and external image URLs return HTTP 200
- Add content_check Makefile target and CI step so these issues are
  caught before deployment

https://claude.ai/code/session_01BraGMR2gMhVb2eUtrikVAF