### PR TITLE
Fix broken images from unescaped HTML in image shortcode

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,6 +31,9 @@ jobs:
       - name: Build site
         run: make build
 
+      - name: Check content structure and images
+        run: make content_check
+
       - name: Deploy site
         env:
           S3_BUCKET: ${{ secrets.S3_BUCKET }}

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -33,7 +33,10 @@ module.exports = function (config) {
 
   // Shortcodes replacing the _includes partials.
   config.addShortcode("image", function (url, alt, width = 480, cls = "") {
-    return `<div class="centred ${cls}"><img src="${url}" alt="${alt}" width="${width}px" class="responsive-image"/></div>`;
+    const escapedAlt = (alt || "")
+      .replace(/&/g, "&amp;")
+      .replace(/"/g, "&quot;");
+    return `<div class="centred ${cls}"><img src="${url}" alt="${escapedAlt}" width="${width}px" class="responsive-image"/></div>`;
   });
 
   config.addShortcode(


### PR DESCRIPTION
The image shortcode was injecting alt text directly into HTML attributes
without escaping. When alt text contained double quotes (e.g. the
fear-and-self-loathing post with "cynical" and "hopeful"), the resulting
HTML was malformed, causing browsers to misparse the <img> tag and fail
to render images.

- Escape & and " in the image shortcode's alt attribute output
- Handle undefined alt text gracefully (some older posts omit it)
- Add HTML validation to check_content.py that detects <img> tags with
  unexpected attribute names (the symptom of broken quote escaping)
- Add content_check step to deploy.yml so broken content is blocked
  before deployment, not just flagged in CI

https://claude.ai/code/session_01HH8RwssztmXHPb2YR8iXP9